### PR TITLE
Fix Spellcaster/Blessed One Detection

### DIFF
--- a/modules/actor/actor-dsa5.js
+++ b/modules/actor/actor-dsa5.js
@@ -403,6 +403,11 @@ export default class Actordsa5 extends Actor {
                         break;
                     case "specialability":
                         specAbs[i.data.category.value].push(i)
+                        if (i.data.category.value === "magical") {
+                            magic.hasSpells = true;
+                        } else if (i.data.category.value === "clerical") {
+                            magic.hasPrayers = true;
+                        }
                         break;
                 }
 


### PR DESCRIPTION
Treat characters as spellcaster/blessed one if there is a magical/karmic SA.