### PR TITLE
Attacks have to be confirmed critical to damage on parry

### DIFF
--- a/modules/system/equipment-damage.js
+++ b/modules/system/equipment-damage.js
@@ -33,9 +33,15 @@ export default class EquipmentDamage {
 
     static async showDamageToGear(preData, testData) {
         if (game.settings.get("dsa5", "armorAndWeaponDamage")) {
+            let actor = DSA5_Utility.getSpeaker(preData.extra.speaker);
+            let attackSuccessLevel = 0;
+            if (actor.data.flags.oppose) {
+                let attackMessage = game.messages.get(actor.data.flags.oppose.messageId);
+                attackSuccessLevel = attackMessage.data.flags.data.postData.successLevel;
+            }
             const source = preData.source
             if (source._id && source.data.structure && (testData.successLevel < -2 ||
-                    preData.situationalModifiers.some(x => x.name.trim() == `${game.i18n.localize('MODS.defenseMalus')} - ${game.i18n.localize('halfDefenseShort')}`)) && ["meleeweapon", "rangeweapon", "armor"].includes(source.type)) {
+                attackSuccessLevel > 2) && ["meleeweapon", "rangeweapon", "armor"].includes(source.type)) {
                 const actor = await DSA5_Utility.getSpeaker(testData.speaker)
                 return actor.items.get(source._id).uuid
             }


### PR DESCRIPTION
This is missing from the 3.1.2 patch. Now without check for successful parry as requested