### PR TITLE
allow effect to be limited to certain Spell Property

### DIFF
--- a/modules/actor/actor-dsa5.js
+++ b/modules/actor/actor-dsa5.js
@@ -377,7 +377,7 @@ export default class Actordsa5 extends Actor {
 
     }
 
-    getSkillModifier(name, sourceType) {
+    getSkillModifier(name, sourceType, sourceData) {
         let result = []
         const keys = ["FP", "step", "QL", "TPM", "FW"]
         for (const k of keys) {
@@ -390,7 +390,20 @@ export default class Actordsa5 extends Actor {
                 }
             }))
             if (this.data.data.skillModifiers[sourceType]) {
-                result.push(...this.data.data.skillModifiers[sourceType][k].map((f) => {
+                result.push(...this.data.data.skillModifiers[sourceType][k].filter((x) => {
+                        if(sourceType == "spell") {
+                            let vals = x.target.split(':')
+                            switch (vals[0]) {
+                                case "M":
+                                case "P":
+                                    return vals[1] == sourceData.feature
+                                default:
+                                    return vals[0] == name
+                            }
+                        } else {
+                            return true
+                        }                        
+                    }).map((f) => {
                     return {
                         name: f.source,
                         value: f.value,

--- a/modules/item/item-dsa5.js
+++ b/modules/item/item-dsa5.js
@@ -672,7 +672,7 @@ class SpellItemDSA5 extends Itemdsa5 {
                 if (target.actor) this.addCreatureTypeModifiers(target.actor.data, source, situationalModifiers)
             });
         }
-        situationalModifiers.push(...actor.getSkillModifier(source.name, source.type))
+        situationalModifiers.push(...actor.getSkillModifier(source.name, source.type, source.data))
         for (const thing of actor.data.data.skillModifiers.global) {
             situationalModifiers.push({ name: thing.source, value: thing.value })
         }


### PR DESCRIPTION
Currently effect that target spells cannot be filtered at all and apply to all spells (and can then be deselected)

This introduces the syntax M:Illusion 1 to only display the modifier during a spell test that is a spell with the property Illusion
If M: is committed it treats the target as a spell Name

All other modifiers keep the existing behavior of ignoring the target

There a many Skills in the magic branch that can make use of this (probably at least one for every Spell Property)

It might need some better localization to make the syntax more resilient for future languages.
Also there might some additional filter criteria, that could make use of this so the switch statement could be extended.
This is mostly a proof of concept so use it as an inspiration if you wish; or not :)

The Pull Request view is just much easier to explain what I would like / propose than creating a issue