### PR TITLE
Fix melee distance comparison

### DIFF
--- a/modules/item/item-dsa5.js
+++ b/modules/item/item-dsa5.js
@@ -475,7 +475,18 @@ export default class Itemdsa5 extends Item {
                         (x.type == "trait" && x.system.traitType.value == "meleeAttack" && x.system.pa)
                     )
                 })
-                if (defWeapon.length > 0) targetWeaponSize = defWeapon[0].system.reach.value
+                if (defWeapon.length > 0) {
+                    for(const weapon of defWeapon) {
+                        switch(targetWeaponSize) {
+                            case "short":
+                                targetWeaponSize = weapon.system.reach.value
+                                break
+                            case "medium":
+                                if (weapon.system.reach.value == "long") targetWeaponSize = "long"
+                                break
+                        }
+                    }
+                }
             }
         })
         


### PR DESCRIPTION
Currently the melee distance comparison is dependent on the order of Item creation.

For example, a warrior with shield (range short) and sword (range medium) is being attacked.
Now depending on wether the shield or sword was added first, the old code returns a melee range of short or medium.

This fixes this, so that always the largest currently equipped range is being used,