### PR TITLE
sightModifier as system property

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -643,7 +643,8 @@
         "armor": "Rüstungsmodifikator",
         "range": "Reichweitenfaktor",
         "creatureBonus": "Bonusschaden (Kreatur)",
-        "armorPen": "Rüstungsdurchdringung"
+        "armorPen": "Rüstungsdurchdringung",
+        "sight": "Sichtmodifikator"
     },
     "WIZARD": {
         "addItem": "{item} hinzufügen",

--- a/lang/de.json
+++ b/lang/de.json
@@ -644,7 +644,8 @@
         "range": "Reichweitenfaktor",
         "creatureBonus": "Bonusschaden (Kreatur)",
         "armorPen": "Rüstungsdurchdringung",
-        "sight": "Sichtmodifikator"
+        "sight": "Sichtmodifikator",
+        "sightMax": "Sichtmodifikator inkl. Stufe 4"
     },
     "WIZARD": {
         "addItem": "{item} hinzufügen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -706,7 +706,8 @@
         "range": "Range multiplier",
         "creatureBonus": "Bonus damage (creature)",
         "armorPen": "Armor penetration",
-        "sight": "Sight modifier"
+        "sight": "Sight modifier",
+        "sightMax": "Sight modifier incl. Level 4"
     },
     "wrongGrip": {
         "oneHanded": "One-handed guided",

--- a/lang/en.json
+++ b/lang/en.json
@@ -705,7 +705,8 @@
         "armor": "Armor modifier",
         "range": "Range multiplier",
         "creatureBonus": "Bonus damage (creature)",
-        "armorPen": "Armor penetration"
+        "armorPen": "Armor penetration",
+        "sight": "Sight modifier"
     },
     "wrongGrip": {
         "oneHanded": "One-handed guided",

--- a/modules/dialog/dialog-combat-dsa5.js
+++ b/modules/dialog/dialog-combat-dsa5.js
@@ -244,7 +244,7 @@ export default class DSA5CombatDialog extends DialogShared {
                 }
 
                 level = Math.max(0, level - blindCombat);
-                if (level < 4 || getProperty(actor, "system.sightModifier.maxLevel")) {
+                if (level < 4 || getProperty(actor, "system.sightModifier.maxLevel") == true) {
                     level = Math.min(
                         Math.max(
                             0, 

--- a/modules/dialog/dialog-combat-dsa5.js
+++ b/modules/dialog/dialog-combat-dsa5.js
@@ -223,7 +223,6 @@ export default class DSA5CombatDialog extends DialogShared {
 
             const actor = DSA5_Utility.getSpeaker(this.dialogData.speaker);
             if (actor) {
-                console.log(actor.system.sightModifier)
                 const darkSightLevel = AdvantageRulesDSA5.vantageStep(actor, game.i18n.localize("LocalizedIDs.darksight")) + SpecialabilityRulesDSA5.abilityStep(actor, game.i18n.localize("LocalizedIDs.sappeurStyle"));
                 const blindCombat = SpecialabilityRulesDSA5.abilityStep(actor, game.i18n.localize("LocalizedIDs.blindFighting"));
                 if (level < 4 && level > 0) {
@@ -245,13 +244,15 @@ export default class DSA5CombatDialog extends DialogShared {
                 }
 
                 level = Math.max(0, level - blindCombat);
-                level = Math.min(
-                    Math.max(
-                        0, 
-                        level + actor.system.sightModifier
-                    ), 
-                    4
-                );
+                if (level < 4 || getProperty(actor, "system.sightModifier.maxLevel")) {
+                    level = Math.min(
+                        Math.max(
+                            0, 
+                            level + (getProperty(actor, "system.sightModifier.value") || 0)
+                        ), 
+                        4
+                    );
+                }
             }
 
             const elem = html.find(`[name="vision"] option:nth-child(${level + 1})`);

--- a/modules/dialog/dialog-combat-dsa5.js
+++ b/modules/dialog/dialog-combat-dsa5.js
@@ -223,6 +223,7 @@ export default class DSA5CombatDialog extends DialogShared {
 
             const actor = DSA5_Utility.getSpeaker(this.dialogData.speaker);
             if (actor) {
+                console.log(actor.system.sightModifier)
                 const darkSightLevel = AdvantageRulesDSA5.vantageStep(actor, game.i18n.localize("LocalizedIDs.darksight")) + SpecialabilityRulesDSA5.abilityStep(actor, game.i18n.localize("LocalizedIDs.sappeurStyle"));
                 const blindCombat = SpecialabilityRulesDSA5.abilityStep(actor, game.i18n.localize("LocalizedIDs.blindFighting"));
                 if (level < 4 && level > 0) {
@@ -244,6 +245,13 @@ export default class DSA5CombatDialog extends DialogShared {
                 }
 
                 level = Math.max(0, level - blindCombat);
+                level = Math.min(
+                    Math.max(
+                        0, 
+                        level + actor.system.sightModifier
+                    ), 
+                    4
+                );
             }
 
             const elem = html.find(`[name="vision"] option:nth-child(${level + 1})`);

--- a/modules/status/active_effects.js
+++ b/modules/status/active_effects.js
@@ -546,6 +546,12 @@ export default class DSAActiveEffectConfig extends ActiveEffectConfig {
                 mode: 0,
                 ph: descriptor,
             },
+            {
+                name: `${game.i18n.localize("MODS.sight")}`,
+                val: `system.sightModifier`,
+                mode: 2,
+                ph: "1",
+            },
         ];
         const models = ["liturgy", "ceremony", "spell", "ritual", "skill", "feature"];
         for (const k of models) {

--- a/modules/status/active_effects.js
+++ b/modules/status/active_effects.js
@@ -548,9 +548,15 @@ export default class DSAActiveEffectConfig extends ActiveEffectConfig {
             },
             {
                 name: `${game.i18n.localize("MODS.sight")}`,
-                val: `system.sightModifier`,
+                val: `system.sightModifier.value`,
                 mode: 2,
                 ph: "1",
+            },
+            {
+                name: `${game.i18n.localize("MODS.sightMax")}`,
+                val: `system.sightModifier.maxLevel`,
+                mode: 5,
+                ph: "true",
             },
         ];
         const models = ["liturgy", "ceremony", "spell", "ritual", "skill", "feature"];


### PR DESCRIPTION
Mit diesem PR wird ein Attributschlüssel für einen Sichtmodifikator zu Veränderung der [Sichtstörungskategorien ](https://ulisses-regelwiki.de/Sichtstoerungen.html) eingeführt. Dadurch soll es möglich sein, den Effekt von Zaubern wie [Katzenaugen](https://ulisses-regelwiki.de/zauber.html?zauber=Katzenaugen) zu automatisieren. Der Attributschlüssel könnte auch die bisherige Umsetzung von SF und Vor-/Nachteilen, die die Sicht beeinflussen, wie beispielsweise Dunkelsicht, ablösen und erlaubt ein höheres Maß an Flexibilität.