### PR TITLE
Praxisbezug (The Riverlands) - obsolet

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -185,7 +185,15 @@
         "selectGroupCheckSkill": "Wähle ein weiteres Talent für die Gruppensammelprobe.",
         "updateMaintainSpell": "Für {actor} ein neues Interval bezahlen oder den Effekt beenden?",
         "dependentMaintainEffects": "Abhängige Effekte (Ebenfalls löschen)",
-        "temporaryOff": "Vorübergehend deaktivieren"
+        "temporaryOff": "Vorübergehend deaktivieren",
+        "confirm": "Bestätigen",
+		"cancel": "Abbrechen",
+		"Praxisbezug": "Praxisbezug",
+		"PraxisbezugTitle": "Praxisbezug anwenden",
+		"PraxisbezugDescription": "In einer passenden Situation darf der Held vor einer Talentprobe den Versuch wagen, sein theoretisches Wissen praktisch einzusetzen. Dabei legt er zunächst eine Probe auf ein passendes Wissenstalent ab.",
+		"PraxisbezugInstruction": "Du kannst Erleichterungen in Höhe von {qs} auf die Teilproben festlegen.",
+		"PraxisbezugLimit": "(Maximal 2 pro Attribut)",
+		"PraxisbezugMaxQS": "Es sind maximal {qs} Punkte verteilbar."
     },
     "Equipment": {
         "misc": "Allgemein",
@@ -2775,5 +2783,9 @@
                 "owned": "Besitzt"
             }
         }
+    },
+    "LOCAL": {
+        "knowledgeTalentsList": "Brett- & Glücksspiel, Geographie, Geschichtswissen, Götter & Kulte, Kriegskunst, Magiekunde, Mechanik, Rechnen, Rechtskunde, Sagen & Legenden, Sphärenkunde, Sternkunde",
+        "praxisbezugAbility": "Praxisbezug"
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -161,7 +161,15 @@
         "selectGroupCheckSkill": "Chose another talent for the cumulative group check.",
         "updateMaintainSpell": "Pay for a new interval or end the effect for {actor}?",
         "dependentMaintainEffects": "Dependent effects (delete too)",
-        "temporaryOff": "Disable temporarily"
+        "temporaryOff": "Disable temporarily",
+		"confirm": "Confirm",
+		"cancel": "Cancel",
+		"Praxisbezug": "Practical Application",
+		"PraxisbezugTitle": "Use Practical Application",
+		"PraxisbezugDescription": "In a suitable situation, the hero may attempt to apply their theoretical knowledge practically before a talent roll. First, make a roll on a suitable Knowledge Talent.",
+		"PraxisbezugInstruction": "You can assign bonuses equal to {qs} to the partial checks.",
+		"PraxisbezugLimit": "(Maximum 2 per attribute)",
+		"PraxisbezugMaxQS": "A maximum of {qs} points can be distributed."
     },
     "Equipment": {
         "misc": "General",
@@ -2773,5 +2781,9 @@
                 "owned": "Owned"
             }
         }
+    },
+    "LOCAL": {
+        "knowledgeTalentsList": "Gambling, Geography, History, Religions, Warfare, Magical Lore, Mechanics, Math, Law, Myths & Legends, Sphere Lore, Astronomy",
+        "praxisbezugAbility": "Practical Application"
     }
 }

--- a/modules/dialog/dialog-skill-dsa5.js
+++ b/modules/dialog/dialog-skill-dsa5.js
@@ -67,7 +67,8 @@ export default class DSA5SkillDialog extends DialogShared {
   	const actor = DSA5_Utility.getSpeaker(this.dialogData.speaker);
       if(actor) { 
           const currentSkillName = this.dialogData.source.name;
-          const hasPraxisbezug = actor.items.some(x => x.type == "specialability" && (x.name == "Praxisbezug" || x.name == "Practical Application"));
+          const sfName = game.i18n.localize('LOCAL.praxisbezugAbility');
+          const hasPraxisbezug = actor.items.some(x => x.type == "specialability" && x.name == sfName);
           const talentsString = game.i18n.localize('LOCAL.knowledgeTalentsList');
           const knowledgeTalents = talentsString.split(',').map(t => t.trim());
           const isKnowledge = knowledgeTalents.includes(currentSkillName) || (this.dialogData.source.system.group && this.dialogData.source.system.group.value == "knowledge");

--- a/modules/dialog/dialog-skill-dsa5.js
+++ b/modules/dialog/dialog-skill-dsa5.js
@@ -176,7 +176,6 @@ class PraxisbezugDialog extends Dialog {
         this.qs = 0;
         this.rolled = false;
         
-        // Hier wird die Funktion aufgerufen, die den Fehler verursacht hat
         this.data.content = this._buildInitialContent();
         
         this.data.buttons = {
@@ -200,7 +199,6 @@ class PraxisbezugDialog extends Dialog {
         let html = `<p>${game.i18n.localize("DIALOG.PraxisbezugDescription")}</p><hr>`;
         html += `<div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">`;
         
-        // --- Liste dynamisch laden ---
         const talentsString = game.i18n.localize('LOCAL.knowledgeTalentsList');
         const knowledgeTalents = talentsString.split(',').map(t => t.trim());
 
@@ -250,7 +248,6 @@ class PraxisbezugDialog extends Dialog {
                      if (success) {
                          this.qs = testData.qualityStep || 0;
                          this.rolled = true;
-                         // Timeout für Render-Zyklus
                          setTimeout(() => this._updateToDistributionMode(), 50);
                      } else {
                          // Bei Misserfolg: Dialog schließen

--- a/modules/dialog/dialog-skill-dsa5.js
+++ b/modules/dialog/dialog-skill-dsa5.js
@@ -62,8 +62,29 @@ export default class DSA5SkillDialog extends DialogShared {
   async _onRender(context, options) {
     await super._onRender(context, options);
 
-    const html = $(this.element)
-
+    const html = $(this.element);
+    
+  	const actor = DSA5_Utility.getSpeaker(this.dialogData.speaker);
+      if(actor) { 
+          const currentSkillName = this.dialogData.source.name;
+          const hasPraxisbezug = actor.items.some(x => x.type == "specialability" && (x.name == "Praxisbezug" || x.name == "Practical Application"));
+          const talentsString = game.i18n.localize('LOCAL.knowledgeTalentsList');
+          const knowledgeTalents = talentsString.split(',').map(t => t.trim());
+          const isKnowledge = knowledgeTalents.includes(currentSkillName) || (this.dialogData.source.system.group && this.dialogData.source.system.group.value == "knowledge");
+  
+          if (hasPraxisbezug && !isKnowledge && !this.praxisbezugUsed) {
+              const modInput = html.find('[name="testModifier"]');
+              const iconHtml = $(`<i class="fas fa-lightbulb praxisbezug-icon" style="cursor: pointer; position: absolute; left: 19px; transform: translateX(-50%); top: -25px; color: #ffeb3b; text-shadow: 0 0 2px black;" data-tooltip="${game.i18n.localize('DIALOG.Praxisbezug')}"></i>`);
+              modInput.parent().css("position", "relative");
+              modInput.before(iconHtml);
+              iconHtml.on('click', async (ev) => {
+                  ev.preventDefault();
+                  ev.stopPropagation();
+                  new PraxisbezugDialog(actor, this).render(true);
+              });
+          }
+      }
+    
     html.on('change', 'input,select', (ev) => this.rememberFormData(ev));
 
     let targets = this.readTargets();
@@ -140,4 +161,210 @@ export default class DSA5SkillDialog extends DialogShared {
       width: 700,
     },
   };
+}
+
+class PraxisbezugDialog extends Dialog {
+    constructor(actor, parentDialog) {
+        super({
+            title: game.i18n.localize('DIALOG.PraxisbezugTitle'), 
+            content: "", 
+            buttons: {}
+        });
+        this.actor = actor;
+        this.parentDialog = parentDialog;
+        this.qs = 0;
+        this.rolled = false;
+        
+        // Hier wird die Funktion aufgerufen, die den Fehler verursacht hat
+        this.data.content = this._buildInitialContent();
+        
+        this.data.buttons = {
+            cancel: {
+                icon: '<i class="fas fa-times"></i>',
+                label: game.i18n.localize("DIALOG.cancel"),
+                callback: () => this.close()
+            }
+        };
+    }
+
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            width: 500,
+            classes: ["dsa5", "dialog"],
+            resizable: true
+        });
+    }
+
+    _buildInitialContent() {
+        let html = `<p>${game.i18n.localize("DIALOG.PraxisbezugDescription")}</p><hr>`;
+        html += `<div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">`;
+        
+        // --- Liste dynamisch laden ---
+        const talentsString = game.i18n.localize('LOCAL.knowledgeTalentsList');
+        const knowledgeTalents = talentsString.split(',').map(t => t.trim());
+
+        const skills = this.actor.items.filter(i => 
+            i.type == "skill" && knowledgeTalents.includes(i.name)
+        ).sort((a, b) => a.name.localeCompare(b.name));
+
+        for (let skill of skills) {
+            html += `<button class="knowledge-roll-btn" data-id="${skill.id}">${skill.name}</button>`;
+        }
+        html += `</div>`;
+        return html;
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        html.find('.knowledge-roll-btn').click(async (ev) => {
+            ev.preventDefault(); 
+            
+            const skillId = ev.currentTarget.dataset.id;
+            const skill = this.actor.items.get(skillId);
+            
+            // Hook registrieren
+            const hookId = Hooks.once("postProcessDSARoll", (chatOptions, testData) => {
+                 
+                 let source = testData.source;
+                 // Fallback für Source Suche
+                 if (!source && testData.preData && testData.preData.source) {
+                     source = testData.preData.source;
+                 }
+
+                 if (!source) return;
+
+                 const rolledId = source._id || source.id;
+                 
+                 if (String(rolledId) === String(skillId)) {
+                     // Flag setzen: Praxisbezug wurde verwendet
+                     this.parentDialog.praxisbezugUsed = true;
+                     
+                     // Parent neu rendern, damit Lampe verschwindet
+                     this.parentDialog.render(true);
+
+                     // Erfolg prüfen
+                     const success = testData.successLevel > 0;
+
+                     if (success) {
+                         this.qs = testData.qualityStep || 0;
+                         this.rolled = true;
+                         // Timeout für Render-Zyklus
+                         setTimeout(() => this._updateToDistributionMode(), 50);
+                     } else {
+                         // Bei Misserfolg: Dialog schließen
+                         this.close();
+                     }
+                 }
+            });
+
+            this.actor.setupSkill(skill, { }, "roll").then(setupData => {
+                 if(setupData) {
+                    this.actor.basicTest(setupData);
+                 }
+            });
+        });
+
+        if (this.rolled) {
+            const inputs = html.find('.praxis-input');
+            inputs.on('contextmenu', (ev) => {
+                ev.preventDefault();
+                this._changeValue(ev.currentTarget, -1);
+            });
+            inputs.on('click', (ev) => {
+                this._changeValue(ev.currentTarget, 1);
+            });
+            inputs.on('keydown', (ev) => {
+                if (ev.key === "Enter") ev.preventDefault();
+            });
+        }
+    }
+
+    _changeValue(input, delta) {
+        let currentVal = parseInt(input.value) || 0;
+        let newVal = Math.clamp(currentVal + delta, 0, 2);
+        
+        const inputs = $(this.element).find('.praxis-input');
+        let totalUsed = 0;
+        inputs.each((i, el) => {
+            if (el !== input) totalUsed += (parseInt(el.value) || 0);
+        });
+
+        if (totalUsed + newVal <= this.qs) {
+            input.value = newVal;
+        } else {
+            if (delta < 0) input.value = newVal; 
+            else {
+                ui.notifications.warn(game.i18n.format("DIALOG.PraxisbezugMaxQS", {qs: this.qs}));
+            }
+        }
+    }
+
+    _updateToDistributionMode() {
+        const parentSource = this.parentDialog.dialogData.source;
+        const c1 = parentSource.system.characteristic1 ? parentSource.system.characteristic1.value : "mu";
+        const c2 = parentSource.system.characteristic2 ? parentSource.system.characteristic2.value : "kl";
+        const c3 = parentSource.system.characteristic3 ? parentSource.system.characteristic3.value : "in";
+
+        const attrs = [c1, c2, c3];
+        
+        let content = `
+            <div style="margin-bottom: 5px; text-align: center;">
+                <p style="margin: 0;">${game.i18n.format("DIALOG.PraxisbezugInstruction", {qs: this.qs})}</p>
+                <p style="margin: 5px 0 0 0; font-size: 0.9em; color: #555;">${game.i18n.localize("DIALOG.PraxisbezugLimit")}</p>
+            </div>
+        `;
+        
+        content += `<div style="display: flex; justify-content: space-around; margin: 10px 0 25px 0;">`;
+        attrs.forEach((attr, idx) => {
+            const label = game.i18n.localize(`CHARAbbrev.${attr.toUpperCase()}`);
+            content += `
+                <div style="text-align: center;">
+                    <label style="font-weight: bold; font-size: 0.9em;">${label}</label><br>
+                    
+                    <input type="number" class="praxis-input" data-idx="${idx}" value="0" min="0" max="2" 
+                           readonly style="width: 40px; text-align: center; cursor: pointer; height: 25px;" 
+                           data-tooltip="Links-<i class='fas fa-mouse'></i>+1<br>Rechts-<i class='fas fa-mouse'></i>-1">
+                </div>
+            `;
+        });
+        content += `</div>`;
+
+        const newButtons = {
+            confirm: {
+                icon: '<i class="fas fa-check"></i>',
+                label: game.i18n.localize("DIALOG.confirm"),
+                callback: (html) => this._applyBonuses(html)
+            },
+            cancel: {
+                icon: '<i class="fas fa-times"></i>',
+                label: game.i18n.localize("DIALOG.cancel"),
+                callback: () => this.close()
+            }
+        };
+
+        this.data.content = content;
+        this.data.buttons = newButtons;
+        
+        this.render(true);
+
+        setTimeout(() => {
+            this.setPosition({ height: "auto" });
+        }, 50);
+    }
+
+    _applyBonuses(html) {
+        const inputs = html.find('.praxis-input');
+        const bonuses = [0, 0, 0];
+        
+        inputs.each((i, el) => {
+            bonuses[parseInt(el.dataset.idx)] = parseInt(el.value) || 0;
+        });
+
+        const parentHtml = $(this.parentDialog.element);
+        parentHtml.find('[name="ch0"]').val(bonuses[0]);
+        parentHtml.find('[name="ch1"]').val(bonuses[1]);
+        parentHtml.find('[name="ch2"]').val(bonuses[2]);
+        parentHtml.find('[name="ch0"]').trigger('change');
+    }
 }


### PR DESCRIPTION
Automatisierung von Praxisbezug

Voraussetzung: Ein Charakter besitzt die Sonderfertigkeit "Praxisbezug" (deutsch) oder "Practical Application" (englisch).

Auslöser: Der Spieler öffnet den Probendialog für ein Talent, das kein Wissenstalent ist (z.B. Klettern).

Interaktion:
- Über dem ersten Modifikator-Feld erscheint ein gelbes Glühbirnen-Icon.
<img width="419" height="205" alt="grafik" src="https://github.com/user-attachments/assets/87fff7fd-0974-44b3-b54e-902fd19f41ef" />

- Ein Klick darauf öffnet das Fenster "Praxisbezug".
<img width="506" height="363" alt="grafik" src="https://github.com/user-attachments/assets/b02dd5c5-fb64-4cfc-90e5-21ca1b99b048" />

Ablauf:
- Im Fenster werden alle verfügbaren Wissenstalente des Charakters als Buttons angezeigt.
- Der Spieler klickt auf das passende Wissenstalent (z.B. Mechanik für eine Schlösserknacken-Probe).
- Das System öffnet den Dialog.

Ergebnis der "Extra-Probe":
- Misserfolg: Das Fenster schließt sich, es gibt keinen Bonus. Die Glühbirne verschwindet für diesen Versuch.
- Erfolg: Das Fenster aktualisiert sich. Es zeigt nun an: "Du kannst Erleichterungen in Höhe von [QS] auf die Teilproben festlegen."
- Dazu erscheinen drei Eingabefelder für die Attribute der ursprünglichen Probe (z.B. MU/IN/FF).
<img width="501" height="211" alt="grafik" src="https://github.com/user-attachments/assets/4fd75d9e-ae56-4358-9682-8713e6e3d32a" />

Bonus verteilen:
- Der Spieler verteilt die QS-Punkte auf die drei Attribute (Links-Klick +1, Rechts-Klick -1).
- Limitierung: Maximal 2 Punkte pro Attribut und in Summe nicht mehr als die gewürfelten QS.

Abschluss:
- Klick auf "Bestätigen": Die Boni werden in den ursprünglichen Probendialog übertragen. Das Praxisbezug-Fenster schließt sich.
- Die Glühbirne verschwindet, da die Fähigkeit für diese Probe nun genutzt wurde.
